### PR TITLE
🐛 Use countDocuments for mongo query instead of count

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adminjs/mongoose",
-  "version": "4.0.0-reedsy-0.0.1",
+  "version": "4.0.0-reedsy-1.0.0",
   "description": "Mongoose adapter for adminjs",
   "type": "module",
   "exports": {

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -68,7 +68,7 @@ class Resource extends BaseResource {
 
   async count(filters = null) {
     if (Object.keys(convertFilter(filters)).length > 0) {
-      return this.MongooseModel.count(convertFilter(filters))
+      return this.MongooseModel.countDocuments(convertFilter(filters))
     }
     return this.MongooseModel.estimatedDocumentCount()
   }


### PR DESCRIPTION
The count is deprecated we should use countDocuments